### PR TITLE
streaming templates

### DIFF
--- a/lib/media/html.js
+++ b/lib/media/html.js
@@ -54,15 +54,15 @@ Media({
 			template = templateEngine.compile(templateId, (mediaParams && mediaParams.template));
 		}
 
-			
 		return {
 			forEach: function(write){
 				return when(template, function(template){
-					write(template(object));
+					template(object).forEach(write);
 				})
 			}
 		}
 	},
+
 	deserialize: function(inputStream, request){
 		throw new Error("not implemented");
 	}


### PR DESCRIPTION
Another update to html.js.  It now expects the compiled template function to return a forEach able to allow the template rendering to stream.  It should be lazy compiling (we need to discuss how to cache this appropriately) and rendering in stream now.
