### PR TITLE
Updated Html Media Handler

### DIFF
--- a/lib/media/html.js
+++ b/lib/media/html.js
@@ -1,5 +1,5 @@
 /**
-* Media handler for generating HTML from Wiki markup-based doc
+* Media handler for generating HTML from tempaltes
 */
 
 var Media = require("../media").Media,
@@ -7,15 +7,16 @@ var Media = require("../media").Media,
 	transform = require("../html-transform"),
 	Response=require("../jsgi/response").Response,
 	resolver = require("templify/templify").Resolver,
-	when = require("promised-io/promise").when;
+	when = require("promised-io/promise").when,
+	copy = require("commonjs-utils/copy").copy;
 var templateEngine =  require('templify/templify').TemplateEngine({resolver: resolver, store: filesystem});
 
-Media({
+var defaultHandler = {
 	mediaType:"text/html",
 	defaultQuality: .1,
 	getQuality: function(object){
-
-		var contentType = object.getMetadata? object.getMetadata()['content-type'] : object['content-type'];
+	
+			var contentType = object.getMetadata? object.getMetadata()['content-type'] : object['content-type'];
 
 		if (contentType) {
 
@@ -38,6 +39,11 @@ Media({
 		var templateId = mediaParams.template || request['scriptName'] + request['pathInfo'];
 		templateId = mediaParams.templateType ? templateId + "-" + mediaParams['templateType'] : templateId;
 
+
+		if (this.createContext){
+			object = this.createContext(object, mediaParams, request, response);
+		}
+
 		if (!object && !response.status){
 			response.status = 404;
 		}else if ((!response.status || (response.status < 400)) && transform && meta['content-type']){
@@ -47,7 +53,6 @@ Media({
 		//delete any existing content-length headers as the size has changed post conversion/templating
 		delete response.headers['content-length'];
 
-		//TODO update template so we can stream the template rendering
 		if (response.status > 400) {
 			template = templateEngine.compile("/error/"+response.status);	
 		}else{
@@ -57,8 +62,10 @@ Media({
 		return {
 			forEach: function(write){
 				return when(template, function(template){
-					template(object).forEach(write);
-				})
+					return when(object, function(object){
+						template(object).forEach(write);
+					});
+				});
 			}
 		}
 	},
@@ -66,4 +73,16 @@ Media({
 	deserialize: function(inputStream, request){
 		throw new Error("not implemented");
 	}
-});
+};
+
+exports.setupMediaHandler = function(handler){
+	var h = {};
+	copy(defaultHandler, h);	
+	if(handler){
+		copy(handler, h);
+	}
+	Media(h);
+};
+
+exports.setupMediaHandler();
+


### PR DESCRIPTION
This update allows an application to modify the html media handler parameters without requiring an entirely new media handler to be written from scratch.  This is required for the pull request coming momentarily for the pintura example wiki. 
