### PR TITLE
Change default template extension for media handler

### DIFF
--- a/lib/media/html.js
+++ b/lib/media/html.js
@@ -3,10 +3,11 @@
 */
 
 var Media = require("../media").Media,
-	filesystem = require("perstore/store/filesystem").FileSystem({dataFolder: "../templates"}),
+	filesystem = require("perstore/store/filesystem").FileSystem({dataFolder: "../templates", defaultExtension: "template"}),
 	transform = require("../html-transform"),
 	Response=require("../jsgi/response").Response,
 	resolver = require("templify/templify").Resolver,
+	toJSON = require("commonjs-utils/json-ext").stringify,
 	when = require("promised-io/promise").when,
 	copy = require("commonjs-utils/copy").copy;
 var templateEngine =  require('templify/templify').TemplateEngine({resolver: resolver, store: filesystem});
@@ -43,7 +44,6 @@ var defaultHandler = {
 		if (this.createContext){
 			object = this.createContext(object, mediaParams, request, response);
 		}
-
 		if (!object && !response.status){
 			response.status = 404;
 		}else if ((!response.status || (response.status < 400)) && transform && meta['content-type']){
@@ -62,9 +62,7 @@ var defaultHandler = {
 		return {
 			forEach: function(write){
 				return when(template, function(template){
-					return when(object, function(object){
-						template(object).forEach(write);
-					});
+					template(object).forEach(write);
 				});
 			}
 		}


### PR DESCRIPTION
These patches set the default extension for templates to ".template"
