### PR TITLE
[cla] Error when starting remote REPL

### DIFF
--- a/lib/util/repl.js
+++ b/lib/util/repl.js
@@ -15,7 +15,8 @@ exports.start = function(context){
 
 	if(settings.replPort){
 		require("net").createServer(function (socket) {
-			var repl = require("repl").start("node>", socket).context.require = require;
+			var repl = require("repl").start("node>", socket);
+			repl.context.require = require;
 			for (var i in context) if (context.hasOwnProperty(i)) repl.context[i] = context[i];
 		}).listen(settings.replPort);
 	}


### PR DESCRIPTION
When connecting to a REPL server:

```
jar:http://github.com/kriszyp/pintura/zipball/v0.2.5!/lib/util/repl.js:19
for (var i in context) if (context.hasOwnProperty(i)) repl.context[i] = context[i];
                                                                      ^
TypeError: Cannot set property 'require' of undefined
    at Server.<anonymous> (jar:http://github.com/kriszyp/pintura/zipball/v0.2.5!/lib/util/repl.js:19:74)
    at Server.emit (events.js:31:17)
    at IOWatcher.callback (net.js:853:12)
```
