### PR TITLE
Improved context management

### DIFF
--- a/lib/jsgi/context.js
+++ b/lib/jsgi/context.js
@@ -2,14 +2,21 @@
  * Provides the request as the context (across async promises)
  */
 var promiseModule = require("promised-io/promise");
+var copy = require("commonjs-utils/copy").copy;
+
 exports.SetContext= function(vars, nextApp){
-	return function(request){
-		try{
-			promiseModule.currentContext = request.context = ((typeof vars === 'function') ? vars(request) : vars) || {};
-			return nextApp(request);
-		}
-		finally{
-			promiseModule.currentContext = null;
-		}
-	};
+    return function(request){
+        try{
+            var startingContext = copy(((typeof vars === 'function') ? vars(request) : vars) || {} , {});
+            promiseModule.currentContext = request.context = startingContext;
+            return nextApp(request);
+        } finally{
+            if(promiseModule.currentContext && 
+                promiseModule.currentContext.suspend && 
+                typeof promiseModule.currentContext.suspend == "function"){
+                promiseModule.currentContext.suspend();
+            }
+            promiseModule.currentContext = null;
+        }
+    };
 };


### PR DESCRIPTION
This change fixes two issues:
- Contexts could be leaked (through the vars variable) between requests.  The vars variable is now copied instead of referenced to prevent this.
- Also, a context that reaches the finally block and is suspendable should be suspended before the current promise context is set to null.

Ultimately, these changes provide part of the foundation for some of the fixes I will be contributing to perstore/transaction.

I and my employer Quantivo have a CLA on file.
