### PR TITLE
Session validate interval

### DIFF
--- a/jsgi/session.js
+++ b/jsgi/session.js
@@ -21,10 +21,14 @@ exports.Session = function(options, nextApp){
 	// start the reaper
 	// TODO: get a timer for narwhal
 	function validate() {
-		exports.getSessionModel().validate();
-		setTimeout(validate, options.expires * 1000);
+		// allow for this to occur asynchronously
+		when(exports.getSessionModel().validate(), function () {
+			setTimeout(validate, options.expires * -1000);
+		});
 	}
-	if (typeof exports.getSessionModel().validate === 'function' && typeof setTimeout !== "undefined") validate();
+	if (typeof exports.getSessionModel().validate === 'function' && typeof setTimeout !== "undefined") {
+		validate();
+	}
 	//
 	return function(request){
 		var session;


### PR DESCRIPTION
improve the session validation logic so that it is called at intervals defined by `settings.sessionTTL`.  

in general, it looks like the existing code has wrong logic if you were to supply `options.expires` but i didn't dig into that.  it looks like, the `setTimeout` for session validation would use `options.expires` as a number that represents an interval of time whereas if you were to follow the logic of the code that creates sessions via `session = exports.forceSession(request, options.expires);`, `forceSession` is going to treat that value as an absolute time representing when the session expires.
