### PR TITLE
provide matching id in message/json response

### DIFF
--- a/media/message/json.js
+++ b/media/message/json.js
@@ -81,7 +81,8 @@ module.exports = Media({
 						id: value.id,
 						metadata: value.headers,
 						error: value.status >= 400 ? value.status : undefined,
-						body: value.body
+						body: value.body,
+						status: value.status
 					});
 				});
 			}else{


### PR DESCRIPTION
this provides an id for each message in the response if there was an id provided in the request.  this is important for clients which batch messages together in a single request.
