### PR TITLE
only write the opening '[' after the first object is received

### DIFF
--- a/media/json.js
+++ b/media/json.js
@@ -28,11 +28,11 @@ function StreamingSerializer(stringify){
 						write("{}&&");
 					}
 					// progressively stream arrays for better performance and memory
-					write("[")
 					var first = true;
 					var undefined; // make it a fast, closely-scoped lookup
 					return when(object.forEach(function(item){
 						if(first){
+							write("[")
 							first = false;
 						}
 						else{


### PR DESCRIPTION
i have an issue only in IE11 where i'm using long-polling for messages/json content and when the request times out i get responses containing `[` instead of an empty response.  i think https://github.com/persvr/pintura/blob/master/media/json.js#L31-L37 is the cause and i'm wondering if `write("[")` should be inside the `if(first)` block.  the `first` variable there seems to imply that might be the intention and it's not doing anything else.

this PR makes that change.
